### PR TITLE
Modify .travis.yml to use new rustup URL.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ env:
   - LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib/rustlib/x86_64-unknown-linux-gnu/lib/
 
 install:
-  - curl www.rust-lang.org/rustup.sh | sudo bash
+  - curl https://static.rust-lang.org/rustup.sh | sudo sh -
 
 script:
   - cargo build -v


### PR DESCRIPTION
The current .travis.yml tries to use the one on www.rust-lang.org,
instead of the one on static.rust-lang.org. This fixes that.
