### PR TITLE
Lifetime bound must be applied to a path not a reference

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -498,7 +498,7 @@ impl<'a> serialize::Decodable<Decoder<'a>, IoError> for Value {
 
 /// A structure for implementing serialization to Msgpack.
 pub struct Encoder<'a> {
-    wr: &'a mut io::Writer + 'a
+    wr: &'a mut (io::Writer + 'a)
 }
 
 impl<'a> Encoder<'a> {


### PR DESCRIPTION
Fixes the following error:

```
/home/drbawb/projects/rust/rust-msgpack/src/lib.rs:501:9: 501:27 error: expected a path on the left-hand side of `+`, not `&'a mut io::Writer` [E0171]
/home/drbawb/projects/rust/rust-msgpack/src/lib.rs:501     wr: &'a mut io::Writer + 'a
                                                               ^~~~~~~~~~~~~~~~~~
/home/drbawb/projects/rust/rust-msgpack/src/lib.rs:501:9: 501:27 note: perhaps you meant `&'a mut (io::Writer + 'a)`? (per RFC 248)
/home/drbawb/projects/rust/rust-msgpack/src/lib.rs:501     wr: &'a mut io::Writer + 'a
                                                               ^~~~~~~~~~~~~~~~~~
```

When compiling with a recent version of `rustc`.
