### PR TITLE
Use `FnMut` where appropriate ...

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -853,7 +853,7 @@ mod test {
                 assert_eq!($inp, value)
             }
         );
-    )
+    );
 
 
     #[test]


### PR DESCRIPTION
Not sure if this will pass travis just yet, as I just compiled my own nightly.
`rustc 0.13.0-dev (c0b2885ee 2014-12-18 06:41:59 +0000)`

A few of the functions in `trait Decoder{}` were relaxed to take closures which can be called more than once.
This will be necessary to fix compiler errors after updating past `rust-lang/rust@22a9f250b`.

See [rust-lang/rust commit 1a05f95](https://github.com/rust-lang/rust/commit/1a05f956f8c34fadfcb3389e70196c93230db5ec) which is part of the latest rollup.
