### PR TITLE
Rust nightly rollup (macro + serialize fn bounds)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -853,7 +853,7 @@ mod test {
                 assert_eq!($inp, value)
             }
         );
-    )
+    );
 
 
     #[test]


### PR DESCRIPTION
This rolls up two changes:
1. Some of the `Fn` trait bounds used in `libserialize` changed upstream. They're now `FnMut` so they can be called multiple times.
   We do not take advantage of this; but the bound still needs to be updated.
2. Macros which expand to items now need a trailing semi-colon
