### PR TITLE
Properly decode `None` variants

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -443,8 +443,8 @@ impl<'a, R: Reader> serialize::Decoder<IoError> for Decoder<R> {
     fn read_option<T,F>(&mut self, mut f: F) -> IoResult<T>
     where F: FnMut(&mut Decoder<R>, bool) -> IoResult<T> {
         match try!(self._peek_byte()) {
-            0xc0 => f(self, false),
-            _    => f(self, true)
+            0xc0 => { self._read_byte(); f(self, false) }, // consume the nil byte from packed format
+            _    => { f(self, true) },
         }
     }
 


### PR DESCRIPTION
This fixes an issue where a `None` corrupts the next value in the stream.
When a `None` variant is encountered this patch consumes the byte which was used to represent it.

This fixes issue #41.
