### PR TITLE
Make it compilable with rust 1.0.0-alpha.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ authors = [
     "Erick Tryzelaar",
     "OGINO Masanori",
     "Ian Daniher",
-    "Derek Chiang (Enchi Jiang)"
+    "Derek Chiang (Enchi Jiang)",
+    "Evgeny Safronov"
 ]
 license = "MIT/Apache-2.0"

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,10 +1,12 @@
+#![allow(unstable)]
+
 extern crate msgpack;
 
 fn main() {
   let arr = vec!["str1".to_string(), "str2".to_string()];
-  let str = msgpack::Encoder::to_msgpack(&arr).ok().unwrap();
-  println!("Encoded: {}", str);
+  let str = msgpack::Encoder::to_msgpack(&arr).unwrap();
+  println!("Encoded: {:?}", str);
 
-  let dec: Vec<String> = msgpack::from_msgpack(str.as_slice()).ok().unwrap();
-  println!("Decoded: {}", dec);
+  let dec: Vec<String> = msgpack::from_msgpack(str.as_slice()).unwrap();
+  println!("Decoded: {:?}", dec);
 }

--- a/examples/value.rs
+++ b/examples/value.rs
@@ -1,15 +1,15 @@
-#![feature(phase)]
+#![allow(unstable)]
 
-#[phase(plugin, link)] extern crate log;
+#[macro_use] extern crate log;
 extern crate msgpack;
 
-use std::io::{File};
+use std::io::File;
 use std::os::args;
 
 fn main() {
   let contents = File::open(&Path::new(args()[1].clone())).read_to_end().ok().unwrap();
-  debug!("{}", contents);
+  debug!("{:?}", contents);
 
   let a: msgpack::Value = msgpack::from_msgpack(contents.as_slice()).ok().unwrap();
-  debug!("{}", a);
+  debug!("{:?}", a);
 }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -1,7 +1,7 @@
-use super::{Value,Encoder,Decoder, _invalid_input};
 use serialize;
 use serialize::{Encodable,Decodable};
-use std::io::{IoError, IoResult};
+
+use super::{Value,Encoder,Decoder};
 
 pub enum RpcMessage {
   RpcRequest      {msgid: u32, method: String, params: Vec<Value>}, // 0
@@ -9,50 +9,50 @@ pub enum RpcMessage {
   RpcNotification {method: String, params: Vec<Value>} // 2
 }
 
-impl<'a> serialize::Encodable<Encoder<'a>, IoError> for RpcMessage {
-  fn encode(&self, s: &mut Encoder<'a>) -> IoResult<()> {
+impl serialize::Encodable for RpcMessage {
+  fn encode<E: serialize::Encoder>(&self, s: &mut E) -> Result<(), E::Error> {
     match *self {
       RpcMessage::RpcRequest {msgid, ref method, ref params} => {
-        (0u, msgid, method, params).encode(s)
+        (0us, msgid, method, params).encode(s)
       }
       RpcMessage::RpcResponse {msgid, ref error, ref result} => {
-        (1u, msgid, error, result).encode(s)
+        (1us, msgid, error, result).encode(s)
       }
       RpcMessage::RpcNotification {ref method, ref params} => {
-        (2u, method, params).encode(s)
+        (2us, method, params).encode(s)
       }
     }
   }
 }
 
-impl<R: Reader> serialize::Decodable<Decoder<R>, IoError> for RpcMessage {
-  fn decode(s: &mut Decoder<R>) -> IoResult<RpcMessage> {
-    let len = try!(s._read_vec_len());
-    let ty: uint = try!(Decodable::decode(s));
+impl serialize::Decodable for RpcMessage {
+  fn decode<D: serialize::Decoder>(s: &mut D) -> Result<RpcMessage, D::Error> {
+    let len: usize = try!(Decodable::decode(s));
+    let ty: usize = try!(Decodable::decode(s));
 
     match ty {
       0 => {
-        if len != 4 { return Err(_invalid_input("Invalid msgpack-rpc message array length")) }
+        if len != 4 { return Err(s.error("Invalid msgpack-rpc message array length")) }
         let msgid = try!(Decodable::decode(s));
         let method = try!(Decodable::decode(s));
         let params = try!(Decodable::decode(s));
         Ok(RpcMessage::RpcRequest {msgid: msgid, method: method, params: params})
       }
       1 => {
-        if len != 4 { return Err(_invalid_input("Invalid msgpack-rpc message array length")) }
+        if len != 4 { return Err(s.error("Invalid msgpack-rpc message array length")) }
         let msgid = try!(Decodable::decode(s));
         let error = try!(Decodable::decode(s));
         let result = try!(Decodable::decode(s));
         Ok(RpcMessage::RpcResponse {msgid: msgid, error: error, result: result})
       }
       2 => {
-        if len != 3 { return Err(_invalid_input("Invalid msgpack-rpc message array length")) }
+        if len != 3 { return Err(s.error("Invalid msgpack-rpc message array length")) }
         let method = try!(Decodable::decode(s));
         let params = try!(Decodable::decode(s));
         Ok(RpcMessage::RpcNotification {method: method, params: params})
       }
       _ => {
-        Err(_invalid_input("Invalid msgpack-rpc message type"))
+        Err(s.error("Invalid msgpack-rpc message type"))
       }
     }
 


### PR DESCRIPTION
This PR should close #45 and #23.

 * Drop no longer required 'macro_rules' and 'globs' crate attributes, because they are part of the language now.
 * Replaced 'deriving' with 'derive' keyword.
 * Replaced int/uint with isize/usize respectively.
 * Match 'serialize::Decoder' and 'serialize::Encoder' interface.
 * Use num cast instead of removed 'to_*' methods.
 * Allow unstable items (because I don't know what to do with them now).
 * Fixed tests.
 * Use new '{:?}' syntax in examples instead of '{}' to print messages generated via Show trait.
 * Added myself in authors list.