### PR TITLE
Update to stable rustc and current byteorder.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Simply include the rust-msgpack in your Cargo dependencies.
 ```toml
 [dependencies.msgpack]
 
-git = "git@github.com:mneumann/rust-msgpack.git"
+git = "https://github.com/mneumann/rust-msgpack"
 ```
 
 ## Quickstart

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1,39 +1,39 @@
 use std::io::Write;
-use byteorder::{self,BigEndian, WriteBytesExt};
+use byteorder::{BigEndian, WriteBytesExt};
 use std::{self, mem};
 
 #[inline]
-fn encode_u7<W:Write>(wr: &mut W, val: u8) -> byteorder::Result<()> {
+fn encode_u7<W:Write>(wr: &mut W, val: u8) -> std::io::Result<()> {
     debug_assert!(val <= 127);
     wr.write_u8(val as u8)
 }
 
 #[inline]
-fn encode_u8<W:Write>(wr: &mut W, val: u8) -> byteorder::Result<()> {
+fn encode_u8<W:Write>(wr: &mut W, val: u8) -> std::io::Result<()> {
     try!(wr.write_u8(0xcc));
     wr.write_u8(val)
 }
 
 #[inline]
-fn encode_u16<W:Write>(wr: &mut W, val: u16) -> byteorder::Result<()> {
+fn encode_u16<W:Write>(wr: &mut W, val: u16) -> std::io::Result<()> {
     try!(wr.write_u8(0xcd));
     wr.write_u16::<BigEndian>(val)
 }
 
 #[inline]
-fn encode_u32<W:Write>(wr: &mut W, val: u32) -> byteorder::Result<()> {
+fn encode_u32<W:Write>(wr: &mut W, val: u32) -> std::io::Result<()> {
     try!(wr.write_u8(0xce));
     wr.write_u32::<BigEndian>(val)
 }
 
 #[inline]
-fn encode_u64<W:Write>(wr: &mut W, val: u64) -> byteorder::Result<()> {
+fn encode_u64<W:Write>(wr: &mut W, val: u64) -> std::io::Result<()> {
     try!(wr.write_u8(0xcf));
     wr.write_u64::<BigEndian>(val)
 }
 
 /// Encodes the most efficient representation of the given unsigned integer
-pub fn encode_unsigned<W:Write>(wr: &mut W, val: u64) -> byteorder::Result<()> {
+pub fn encode_unsigned<W:Write>(wr: &mut W, val: u64) -> std::io::Result<()> {
     if val <= 127 {
         encode_u7(wr, val as u8)
     }
@@ -52,7 +52,7 @@ pub fn encode_unsigned<W:Write>(wr: &mut W, val: u64) -> byteorder::Result<()> {
 }
 
 #[inline]
-fn encode_op_len<W:Write>(wr: &mut W, len: u32, op_sz1: Option<(u8, u32)>, op2_opt: Option<u8>, op16: u8, op32: u8) -> byteorder::Result<()> {
+fn encode_op_len<W:Write>(wr: &mut W, len: u32, op_sz1: Option<(u8, u32)>, op2_opt: Option<u8>, op16: u8, op32: u8) -> std::io::Result<()> {
     if let Some((op1, sz1)) = op_sz1 {
         if len <= sz1 {
             return wr.write_u8(op1 | ((len & sz1) as u8))
@@ -73,27 +73,27 @@ fn encode_op_len<W:Write>(wr: &mut W, len: u32, op_sz1: Option<(u8, u32)>, op2_o
     }
 }
 
-pub fn encode_str_len<W:Write>(wr: &mut W, len: u32) -> byteorder::Result<()> {
+pub fn encode_str_len<W:Write>(wr: &mut W, len: u32) -> std::io::Result<()> {
     encode_op_len(wr, len, Some((0xa0, 31)), Some(0xd9), 0xda, 0xdb)
 }
 
-pub fn encode_bin_len<W:Write>(wr: &mut W, len: u32) -> byteorder::Result<()> {
+pub fn encode_bin_len<W:Write>(wr: &mut W, len: u32) -> std::io::Result<()> {
     encode_op_len(wr, len, None, Some(0xc4), 0xc5, 0xc6)
 }
 
-pub fn encode_vec_len<W:Write>(wr: &mut W, len: u32) -> byteorder::Result<()> {
+pub fn encode_vec_len<W:Write>(wr: &mut W, len: u32) -> std::io::Result<()> {
     encode_op_len(wr, len, Some((0x90, 15)), None, 0xdc, 0xdd)
 }
 
-pub fn encode_map_len<W:Write>(wr: &mut W, len: u32) -> byteorder::Result<()> {
+pub fn encode_map_len<W:Write>(wr: &mut W, len: u32) -> std::io::Result<()> {
     encode_op_len(wr, len, Some((0x80, 15)), None, 0xde, 0xdf)
 }
 
-pub fn encode_nil<W:Write>(wr: &mut W) -> byteorder::Result<()> {
+pub fn encode_nil<W:Write>(wr: &mut W) -> std::io::Result<()> {
     wr.write_u8(0xc0)
 }
 
-pub fn encode_bool<W:Write>(wr: &mut W, val: bool) -> byteorder::Result<()> {
+pub fn encode_bool<W:Write>(wr: &mut W, val: bool) -> std::io::Result<()> {
     if val {
         wr.write_u8(0xc3)
     } else {
@@ -101,23 +101,19 @@ pub fn encode_bool<W:Write>(wr: &mut W, val: bool) -> byteorder::Result<()> {
     }
 }
 
-pub fn encode_str<W:Write>(wr: &mut W, val: &str) -> byteorder::Result<()> {
+pub fn encode_str<W:Write>(wr: &mut W, val: &str) -> std::io::Result<()> {
     let len = val.len();
     assert!(len <= std::u32::MAX as usize);
     try!(encode_str_len(wr, len as u32));
-    // XXX There has to be a better way to do this...
-    match wr.write_all(val.as_bytes()) {
-        Ok(_)  => Ok(()),
-        Err(e) => Err(byteorder::Error::Io(e))
-    }
+    wr.write_all(val.as_bytes())
 }
 
-pub fn encode_f32<W:Write>(wr: &mut W, val: f32) -> byteorder::Result<()> {
+pub fn encode_f32<W:Write>(wr: &mut W, val: f32) -> std::io::Result<()> {
     try!(wr.write_u8(0xca));
     unsafe { wr.write_u32::<BigEndian>(mem::transmute(val)) }
 }
 
-pub fn encode_f64<W:Write>(wr: &mut W, val: f64) -> byteorder::Result<()> {
+pub fn encode_f64<W:Write>(wr: &mut W, val: f64) -> std::io::Result<()> {
     try!(wr.write_u8(0xcb));
     unsafe { wr.write_u64::<BigEndian>(mem::transmute(val)) }
 }

--- a/src/slice_reader.rs
+++ b/src/slice_reader.rs
@@ -267,7 +267,7 @@ pub fn parse_next<'a>(data: &'a[u8]) -> Result<(Value<'a>, &'a[u8]), Error> {
             if c <= 0x7f {
                 return Ok((Value::Unsigned(c as u64), rest));
             }
-            if c >= 0xe0 && c <= 0xff {
+            if c >= 0xe0 {
                 return Ok((Value::Signed((c as i8) as i64), rest));
             }
             if c >= 0xa0 && c <= 0xbf {
@@ -465,12 +465,10 @@ impl<'a> Reader<'a> {
 #[test]
 fn test_decode() {
     use super::encode_into;
-    use rustc_serialize::Encodable;
-    use super::Encoder;
 
     let mut v = Vec::new();
 
-    encode_into(&mut v, &1234u64);
+    assert!(encode_into(&mut v, &1234u64).is_ok());
 
     match parse_next(&v[..]) {
         Ok((Value::Unsigned(n), rest)) => {
@@ -484,12 +482,10 @@ fn test_decode() {
 #[test]
 fn test_decode_array() {
     use super::encode_into;
-    use rustc_serialize::Encodable;
-    use super::Encoder;
 
     let mut v = Vec::new();
 
-    encode_into(&mut v, &[1u64, 2u64, 3u64]);
+    assert!(encode_into(&mut v, &[1u64, 2u64, 3u64]).is_ok());
 
     match parse_next(&v[..]) {
         Ok((Value::Array(n), rest)) => {
@@ -515,12 +511,10 @@ fn test_decode_array() {
 #[test]
 fn test_decode_string() {
     use super::encode_into;
-    use rustc_serialize::Encodable;
-    use super::Encoder;
 
     let mut v = Vec::new();
 
-    encode_into(&mut v, &"hello world");
+    assert!(encode_into(&mut v, &"hello world").is_ok());
 
     match parse_next(&v[..]) {
         Ok((Value::String(s), rest)) => {


### PR DESCRIPTION
Removes `#![feature(slice_splits)]`.
Replaces `byteorder::{Error,Result}` with `std::io::{Error,Result}`.
Fixes all warnings (hopefully not breaking things).
Updates github link in readme.

Fixes #55.
